### PR TITLE
Run tests when building package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ test:
     - python {{ python_min }}
     - pip
     - pytest
+    - gofit
   commands:
     - pip check
     - pytest test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - pip
   run:
     - python >={{ python_min }}
+    - joblib
     - numpy
     - scipy
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -28,11 +28,15 @@ requirements:
 test:
   imports:
     - quickBayes
-  commands:
-    - pip check
+  source_files:
+    - test
   requires:
     - python {{ python_min }}
     - pip
+    - pytest
+  commands:
+    - pip check
+    - pytest test
 
 about:
   home: https://github.com/ISISNeutronMuon/quickBayes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,10 +35,9 @@ test:
     - python {{ python_min }}
     - pip
     - pytest
-    - gofit
   commands:
     - pip check
-    - pytest test
+    - pytest test/default test/shared
 
 about:
   home: https://github.com/ISISNeutronMuon/quickBayes


### PR DESCRIPTION
This will run the non-`gofit` tests when building the package. If we try and run all the tests in the same test environment it won't work currently because some tests require `gofit` to be installed, and others require it to not be installed.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
